### PR TITLE
wiki作成ページにタイトルとタグの入力欄を追加

### DIFF
--- a/app/index.html
+++ b/app/index.html
@@ -45,7 +45,6 @@
 
     <!-- build:js scripts/vendor.js -->
     <!-- bower:js -->
-    <script src="bower_components/underscore/underscore.js"></script>
     <script src="bower_components/angular/angular.js"></script>
     <script src="bower_components/angular-resource/angular-resource.js"></script>
     <script src="bower_components/angular-cookies/angular-cookies.js"></script>
@@ -53,6 +52,7 @@
     <script src="bower_components/angular-ui-router/release/angular-ui-router.js"></script>
     <script src="bower_components/marked/lib/marked.js"></script>
     <script src="bower_components/ng-tags-input/ng-tags-input.min.js"></script>
+    <script src="bower_components/underscore/underscore.js"></script>
     <!-- endbower -->
     <!-- endbuild -->
 

--- a/app/index.html
+++ b/app/index.html
@@ -12,6 +12,7 @@
     <!-- Place favicon.ico and apple-touch-icon.png in the root directory -->
     <!-- build:css styles/vendor.css -->
     <!-- bower:css -->
+    <link rel="stylesheet" href="bower_components/ng-tags-input/ng-tags-input.min.css" />
     <!-- endbower -->
     <!-- endbuild -->
     <!-- build:css({.tmp,app}) styles/main.css -->
@@ -44,12 +45,14 @@
 
     <!-- build:js scripts/vendor.js -->
     <!-- bower:js -->
+    <script src="bower_components/underscore/underscore.js"></script>
     <script src="bower_components/angular/angular.js"></script>
     <script src="bower_components/angular-resource/angular-resource.js"></script>
     <script src="bower_components/angular-cookies/angular-cookies.js"></script>
     <script src="bower_components/angular-sanitize/angular-sanitize.js"></script>
     <script src="bower_components/angular-ui-router/release/angular-ui-router.js"></script>
     <script src="bower_components/marked/lib/marked.js"></script>
+    <script src="bower_components/ng-tags-input/ng-tags-input.min.js"></script>
     <!-- endbower -->
     <!-- endbuild -->
 
@@ -59,7 +62,6 @@
         <script src="scripts/controllers/create_wiki.js"></script>
         <script src="scripts/controllers/login.js"></script>
         <script src="scripts/services/entities.js"></script>
-        <script src="scripts/controllers/animation_test.js"></script>
         <!-- endbuild -->
 </body>
 </html>

--- a/app/scripts/app.coffee
+++ b/app/scripts/app.coffee
@@ -1,6 +1,6 @@
 'use strict'
 
-angular.module('RSLWikiApp', ['ui.router','ngCookies','ngResource','ngSanitize','marked'])
+angular.module('RSLWikiApp', ['ui.router','ngCookies','ngResource','ngSanitize','marked','ngTagsInput','underscore'])
 .config ($stateProvider, $urlRouterProvider) ->
   $urlRouterProvider.otherwise '/main'
   $stateProvider.state 'login',
@@ -24,3 +24,4 @@ angular.module('RSLWikiApp', ['ui.router','ngCookies','ngResource','ngSanitize',
 
 #module化したライブラリ
 angular.module('marked', []).factory 'marked', ()=> @.marked
+angular.module('underscore', []).factory '_', ()=> @._

--- a/app/scripts/controllers/create_wiki.coffee
+++ b/app/scripts/controllers/create_wiki.coffee
@@ -1,6 +1,6 @@
 'use strict'
 
-angular.module('RSLWikiApp').controller 'CreateWikiCtrl', ($scope, marked, UserManageAPI) ->
+angular.module('RSLWikiApp').controller 'CreateWikiCtrl', ($scope, marked, UserManageAPI, _) ->
   $scope.markdown = ''
   $scope.pre = ''
   $scope.markdown_change = () ->
@@ -9,6 +9,9 @@ angular.module('RSLWikiApp').controller 'CreateWikiCtrl', ($scope, marked, UserM
     doc =
       user_id: 1
       content: $scope.markdown
-      title: "testTitle"
+      title: $scope.title
+      tags: _.pluck($scope.tags, 'text')
     UserManageAPI.create doc, (result) ->
       console.log result
+    , (e) ->
+      console.log e

--- a/app/scripts/controllers/create_wiki.coffee
+++ b/app/scripts/controllers/create_wiki.coffee
@@ -1,6 +1,6 @@
 'use strict'
 
-angular.module('RSLWikiApp').controller 'CreateWikiCtrl', ($scope, marked, UserManageAPI, _) ->
+angular.module('RSLWikiApp').controller 'CreateWikiCtrl', ($scope, marked, WikiAPI, _) ->
   $scope.markdown = ''
   $scope.pre = ''
   $scope.tags = [
@@ -13,7 +13,7 @@ angular.module('RSLWikiApp').controller 'CreateWikiCtrl', ($scope, marked, UserM
       content: $scope.markdown
       title: $scope.title
       tags: _.pluck($scope.tags, 'text')
-    UserManageAPI.create doc, (result) ->
+    WikiAPI.create doc, (result) ->
       console.log result
     , (e) ->
       console.log e

--- a/app/scripts/controllers/create_wiki.coffee
+++ b/app/scripts/controllers/create_wiki.coffee
@@ -3,6 +3,8 @@
 angular.module('RSLWikiApp').controller 'CreateWikiCtrl', ($scope, marked, UserManageAPI, _) ->
   $scope.markdown = ''
   $scope.pre = ''
+  $scope.tags = [
+  ]
   $scope.markdown_change = () ->
     $scope.pre = marked($scope.markdown)
   $scope.postDoc = () ->

--- a/app/scripts/services/entities.coffee
+++ b/app/scripts/services/entities.coffee
@@ -33,7 +33,7 @@ angular.module('RSLWikiApp').factory "Sessions", ($location, $resource) ->
           auth_token: '@auth_token'
         isArray: false
 
-angular.module('RSLWikiApp').factory "UserManageAPI", ($location, $resource) ->
+angular.module('RSLWikiApp').factory "WikiAPI", ($location, $resource) ->
   $resource "#{test_url}/documents",
       null
     ,

--- a/app/views/create_wiki.haml
+++ b/app/views/create_wiki.haml
@@ -7,5 +7,5 @@
 .preview
   %h2 Preview
   %p#preview-area{'ng-bind-html'=>"pre"}
-%tags-input{ 'ng-model'=>'tags' }
+%tags-input{'ng-model'=>'tags'}
 %button{'ng-click'=>'postDoc()'} POST

--- a/app/views/create_wiki.haml
+++ b/app/views/create_wiki.haml
@@ -1,7 +1,11 @@
+.title
+  %h2 Title
+  %input{'ng-model'=>'title'}
 .editor
   %h2 Markdown
   %textarea#editor-area{'ng-model'=>'markdown', 'ng-change'=>'markdown_change()'}
 .preview
   %h2 Preview
   %p#preview-area{'ng-bind-html'=>"pre"}
+%tags-input{ 'ng-model'=>'tags' }
 %button{'ng-click'=>'postDoc()'} POST

--- a/bower.json
+++ b/bower.json
@@ -2,19 +2,19 @@
   "name": "wiki-front",
   "version": "0.0.0",
   "dependencies": {
-    "angular": "1.2.6",
+    "angular": "1.3.14",
     "json3": "~3.2.6",
     "es5-shim": "~2.1.0",
-    "angular-resource": "1.2.6",
-    "angular-cookies": "1.2.6",
-    "angular-sanitize": "1.2.6",
+    "angular-resource": "1.3.14",
+    "angular-cookies": "1.3.14",
+    "angular-sanitize": "1.3.14",
     "angular-ui-router": "~0.2.13",
     "marked": "~0.3.3",
     "ng-tags-input": "~2.3.0",
     "underscore": "~1.8.2"
   },
   "devDependencies": {
-    "angular-mocks": "1.2.6",
-    "angular-scenario": "1.2.6"
+    "angular-mocks": "1.3.14",
+    "angular-scenario": "1.3.14"
   }
 }

--- a/bower.json
+++ b/bower.json
@@ -9,7 +9,9 @@
     "angular-cookies": "1.2.6",
     "angular-sanitize": "1.2.6",
     "angular-ui-router": "~0.2.13",
-    "marked": "~0.3.3"
+    "marked": "~0.3.3",
+    "ng-tags-input": "~2.3.0",
+    "underscore": "~1.8.2"
   },
   "devDependencies": {
     "angular-mocks": "1.2.6",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,9 @@
 {
   "name": "wikifront",
   "version": "0.0.0",
-  "dependencies": {},
+  "dependencies": {
+    "ng-tags-input": "~2.3.0"
+  },
   "devDependencies": {
     "grunt": "~0.4.1",
     "grunt-autoprefixer": "~0.4.0",


### PR DESCRIPTION
## Why
- タイトル入力欄がまだなかった
- タグ入力欄がまだなかった
## How
- タイトル入力欄を簡易的に作成
- タグ入力欄を簡易的に作成
  [![Gyazo](http://i.gyazo.com/e86cf717fb23808336766e6906fb4c43.png)](http://gyazo.com/e86cf717fb23808336766e6906fb4c43)
### タグ入力欄について
- [ngTagsInput](http://mbenford.github.io/ngTagsInput/)を使用
- (現状、タグ入力欄にフォーカスすると以下のエラーがでる汗)
  [![Gyazo](http://i.gyazo.com/b0b2ce2f57a7f9f86346d4624db1dc53.png)](http://gyazo.com/b0b2ce2f57a7f9f86346d4624db1dc53)
- 上記のエラーは`angular`のバージョン変更で解消
## Others
- `animation_test.js` の読み込み行を削除
- `UserManageAPI` を `WikiAPI` に名称変更
