### PR TITLE
tags-input に key-property を追加

### DIFF
--- a/app/scripts/controllers/create_wiki.coffee
+++ b/app/scripts/controllers/create_wiki.coffee
@@ -31,7 +31,7 @@ angular.module('RSLWikiApp').controller 'CreateWikiCtrl', ($scope, $state, marke
       user_id: storage.get('rsl.current_user').id
       content: $scope.markdown.content
       title: $scope.title
-      tags: _.pluck($scope.tags, 'text')
+      tags: _.pluck($scope.tags, 'name')
     WikiAPI.create doc, (result) ->
       RSLLoading.loading_finish()
       $state.go 'wiki_list'

--- a/app/scripts/controllers/edit_wiki.coffee
+++ b/app/scripts/controllers/edit_wiki.coffee
@@ -1,6 +1,6 @@
 'use strict'
 
-angular.module('RSLWikiApp').controller 'EditWikiCtrl', ($scope, $state, marked, WikiAPI, _, storage, RSLLoading) ->
+angular.module('RSLWikiApp').controller 'EditWikiCtrl', ($scope, $state, marked, WikiAPI, TagAPI, _, storage, RSLLoading) ->
   wiki_id = $state.params.wiki_id
   $scope.tags = []
   WikiAPI.get {"id":wiki_id},(result)=>
@@ -10,11 +10,19 @@ angular.module('RSLWikiApp').controller 'EditWikiCtrl', ($scope, $state, marked,
     $scope.markdown =
       content: wiki.content
     $scope.pre = marked($scope.markdown.content)
-    _.each wiki.tags, (tag)=>
-      $scope.tags.push {"text":tag.name}
+    $scope.tags = wiki.tags
+    $scope.editorOptions =
+      lineWrapping : true
+      lineNumbers: true
+      mode: 'markdown'
+
+  $scope.load_tags = () ->
+    return TagAPI.get_all().$promise
 
   $scope.markdown_change = () ->
     $scope.pre = marked($scope.markdown.content)
+    previewElement = document.getElementById("preview-area")
+    MathJax.Hub.Typeset(previewElement)
 
   $scope.postDoc = () ->
     $scope.errors = []
@@ -27,7 +35,7 @@ angular.module('RSLWikiApp').controller 'EditWikiCtrl', ($scope, $state, marked,
       user_id: storage.get('rsl.current_user').id
       content: $scope.markdown.content
       title: $scope.title
-      tags: _.pluck($scope.tags, 'text')
+      tags: _.pluck($scope.tags, 'name')
     RSLLoading.loading_start()
     WikiAPI.update {"id":wiki_id},doc, (result) ->
       RSLLoading.loading_finish()

--- a/app/views/wiki_form.haml
+++ b/app/views/wiki_form.haml
@@ -5,7 +5,7 @@
       %input{'ng-model'=>'title'}
     %md-button{'ng-click'=>'postDoc()'} POST
 
-  %tags-input{'ng-model'=>'tags' , "display-property"=>"name"}
+  %tags-input{'ng-model'=>'tags', 'key-property'=>'name', "display-property"=>"name"}
     %auto-complete{"source"=>"load_tags()"}
 
   %md-grid-list{'md-cols'=>"2", 'md-gutter'=>"4px", 'md-row-height'=>"500px"}


### PR DESCRIPTION
## Why

[![Gyazo](http://i.gyazo.com/8671c2f824383ec21d52acd41d1aa666.png)](http://gyazo.com/8671c2f824383ec21d52acd41d1aa666)
## How
- [ngTagsInput API documentation](http://mbenford.github.io/ngTagsInput/documentation/api)
- `display-property="name"` だったので `key-property="name"` も追加
