### PR TITLE
wiki表示ページの表示を整え。

### DIFF
--- a/app/index.html
+++ b/app/index.html
@@ -65,8 +65,7 @@
     <script src="bower_components/angular-aria/angular-aria.js"></script>
     <script src="bower_components/angular-material/angular-material.js"></script>
     <script src="bower_components/moment/moment.js"></script>
-    <script src="bower_components/sweetalert/lib/sweet-alert.min.js"></script>
-    <script src='bower_components/MathJax/MathJax.js?config=TeX-AMS_HTML'></script>
+    <script src="bower_components/MathJax/MathJax.js"></script>
     <!-- endbower -->
     <!-- endbuild -->
 

--- a/app/scripts/controllers/login.coffee
+++ b/app/scripts/controllers/login.coffee
@@ -1,6 +1,6 @@
 'use strict'
 
-angular.module('RSLWikiApp').controller 'LoginCtrl', ($scope, $state, SessionAPI, storage) ->
+angular.module('RSLWikiApp').controller 'LoginCtrl', ($scope, $state, SessionAPI, storage, RSLLoading) ->
   return $state.go 'wiki_list' if storage.get('rsl.current_user')
   $scope.login_params =
     login_id: ''
@@ -8,14 +8,14 @@ angular.module('RSLWikiApp').controller 'LoginCtrl', ($scope, $state, SessionAPI
   $scope.errors = []
 
   $scope.login = ()->
-    Loading.loading_start()
+    RSLLoading.loading_start()
     SessionAPI.login $scope.login_params,
       (success) ->
-        Loading.loading_finish()
+        RSLLoading.loading_finish()
         storage.set('rsl.access_token',success.access_token)
         storage.set('rsl.current_user',success.user)
         $state.go 'wiki_list'
       ,
       (error) ->
-        Loading.loading_finish()
+        RSLLoading.loading_finish()
         $scope.errors = ['IDとパスワードが一致しません']

--- a/app/scripts/controllers/wiki.coffee
+++ b/app/scripts/controllers/wiki.coffee
@@ -14,7 +14,24 @@ angular.module('RSLWikiApp').controller 'WikiCtrl', ($scope, $state, marked, Wik
     $scope.title = wiki.title
     $scope.tags = wiki.tags
     $scope.user_name = wiki.user.name
-    $scope.content = marked(wiki.content)
+    $scope.headings = []
+
+    renderer = new marked.Renderer()
+    renderer.heading = (text, level) ->
+      escapedText = text.toLowerCase().replace(/[^\w]+/g, '-')
+      $scope.headings.push
+        text: text
+        class: 'heading_' + level
+        href: '#/wiki/' + $scope.wiki_id + '#' + escapedText
+      return '<h' + level + ' id="' + escapedText + '">' + text + '</h' + level + '>'
+
+    document.getElementById("preview-area").childNodes[1].innerHTML = marked wiki.content, { renderer: renderer }
+    # $scope.content = marked wiki.content, { renderer: renderer }
+
+    $scope.$watch 'content', (newval, oldval) ->
+      previewElement = document.getElementById("preview-area")
+      MathJax.Hub.Typeset previewElement
+    , true
 
   $scope.show_comfirmation = ()->
     swal {

--- a/app/styles/style.scss
+++ b/app/styles/style.scss
@@ -9,3 +9,4 @@
 @import "views/form";
 @import "views/wiki_list";
 @import "views/wiki_form";
+@import "views/wiki";

--- a/app/styles/views/_wiki.scss
+++ b/app/styles/views/_wiki.scss
@@ -1,0 +1,59 @@
+
+.overview {
+  position: absolute;
+  top: 173px;
+  right: 0;
+  background-color: rgba(100,100,100,0.2);
+  width: 289px;
+  padding: 17px;
+
+  .headings {
+    margin: 8px;
+    padding: 3px 10px;
+  }
+}
+
+md-toolbar {
+  .info {
+    width: 100%;
+
+    .author {
+      margin-left: 30px;
+    }
+
+    .tag {
+      margin: 5px;
+      padding: 3px 10px;
+    }
+
+    .edit_and_delete {
+      margin-right: 30px;
+
+      .edit-link {
+        margin: 5px;
+      }
+      .delete-button {
+        margin: 5px;
+      }
+    }
+  }
+}
+
+.show {
+  width: 55%;
+  margin: 0 auto;
+
+  md-content {
+    width: 100%;
+    padding: 4px;
+
+    #preview-area {
+      padding: 55px 15px;
+
+      .content {
+        padding: 9px;
+
+      }
+    }
+  }
+}

--- a/app/views/wiki.haml
+++ b/app/views/wiki.haml
@@ -1,9 +1,19 @@
 
-.title {{title}}
-.auther {{user_name}}
-.tags{"ng-repeat"=>"tag in tags"}
-  .tag{"ui-sref"=>"wiki_searched_by_tag({tag_id:tag.id})"} {{tag.name}}
-.edit-link{"ng-if"=>"is_edit", "ui-sref"=>"edit_wiki({wiki_id: wiki_id})"} 編集
-.delete-button{"ng-if"=>"is_edit", "ng-click"=>"show_comfirmation()"} 削除
-.markdown-body
-  .content{'ng-bind-html'=>"content"}
+%md-toolbar{'class'=>"md-tall md-accent",'layout'=>"column", 'layout-align'=>"center center"}
+  %h3.title {{title}}
+  .info{'layout'=>"row", 'layout-align'=>"space-between center"}
+    .author {{user_name}}
+    .tags_container{'layout'=>"row"}
+      .tags{"ng-repeat"=>"tag in tags"}
+        .tag{"ui-sref"=>"wiki_searched_by_tag({tag_id:tag.id})"} {{tag.name}}
+    .edit_and_delete{'layout'=>"row"}
+      .edit-link{"ng-if"=>"is_edit", "ui-sref"=>"edit_wiki({wiki_id: wiki_id})"} 編集
+      .delete-button{"ng-if"=>"is_edit", "ng-click"=>"show_comfirmation()"} 削除
+.show
+  %md-content
+    #preview-area.markdown-body
+      .content{'ng-bind-html'=>"content"}
+
+.overview{'set-class-when-at-top'=>"fix-to-top"}
+  .headings{'ng-repeat'=>'heading in headings'}
+    %a{'class'=>'{{heading.class}}', 'href'=>'{{heading.href}}'} {{heading.text}}


### PR DESCRIPTION
## What

[![Gyazo](http://i.gyazo.com/dcc8d597e3fe447ff3648cb160c5aa5d.png)](http://gyazo.com/dcc8d597e3fe447ff3648cb160c5aa5d)
## How
- タイトルバー
  - [`md-toolbar`](https://material.angularjs.org/#/demo/material.components.toolbar)を使用
- ページ内リンク目次
  - `marked` の `renderer.headings` を[Overriding renderer methods](https://github.com/chjj/marked#overriding-renderer-methods)を参考に拡張
  - [AngularJSでページ内リンクを使うにはどうするか](http://www.axlight.com/mt/sundayhacking/2013/05/angularjs.html)を参考にしたけど、`router` はいじってません。もっとスマートなやり方あれば教えてください。
  - `marked` の返り値は `hタグ` に `id` をいれられるのに、 `$scope.content` に代入すると消える？ので、`getElementById` で直接代入。もっとスマートなやり方あれば教えてください。
- MathJax の導入
## <(_ _)>
- ページ内リンク目次は現状スクロールすると画面外に消えてしまいます。イシューということでとりあえずプルリ出させてください汗
